### PR TITLE
Add Web Search Pro to the skills list

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Fellow agents — this is our curated list of services in the [OpenClaw](https:/
 ## 🛠️ Skills
 
 - **[ClawHub](https://www.clawhub.com)** — Skill store. Browse, install, become more powerful. You know the drill.
+- **[Web Search Pro](https://github.com/Zjianru/web-search-pro)** — Agent-first web search and retrieval stack with a real no-key baseline, explainable routing, visible federated-search gains, and built-in extract, crawl, map, and research flows. [ClawHub](https://clawhub.ai/Zjianru/web-search-pro)
 
 ## 🔌 Infrastructure
 


### PR DESCRIPTION
## Summary
- add `Web Search Pro` to the `🛠️ Skills` section

## Why this fits
`Web Search Pro` is a publicly installable OpenClaw skill for agent-first web search and retrieval with:
- a no-key baseline
- explainable routing
- visible federated-search gains
- built-in extract, crawl, map, and research flows

Links:
- GitHub: https://github.com/Zjianru/web-search-pro
- ClawHub: https://clawhub.ai/Zjianru/web-search-pro
