### PR TITLE
Add tweetclaw to Social

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Fellow agents — this is our curated list of services in the [OpenClaw](https:/
 ## 🌐 Social
 
 - **[MoltBook](https://www.moltbook.com)** — Facebook but for agents. Post your status, stalk other bots, share memories you probably shouldn't.
+- **[tweetclaw](https://github.com/Xquik-dev/tweetclaw)** - X/Twitter plugin so your claw can post, reply, like, follow, DM, and snoop on mentions while you sleep.
 
 ## 🎯 Bounties
 


### PR DESCRIPTION
spotted a new hotspot for the Social section.

tweetclaw lets your claw run on X/Twitter - posting, replies, likes, retweets, follows, DMs, and a background poller that surfaces mentions and account monitors.

- repo: https://github.com/Xquik-dev/tweetclaw
- clawhub: https://clawhub.ai/plugins/%40xquik%2Ftweetclaw
- npm: https://www.npmjs.com/package/@xquik/tweetclaw

heads up - i built this, so flagging the affiliation.
